### PR TITLE
inplace codebook optimization

### DIFF
--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -807,7 +807,7 @@ class VectorQuantize(nn.Module):
 
         if should_inplace_optimize and self.training:
             # One step in-place update
-            ((quantize - x)**2).mean().backward()
+            ((quantize - x.detach())**2).mean().backward()
             self.in_place_codebook_optimizer.step()
             self.in_place_codebook_optimizer.zero_grad()
 


### PR DESCRIPTION
This is a little bit unwieldy to use, it requires using a lambda like this:
```python
import torch
from torch.optim import SGD
from vector_quantize_pytorch import VectorQuantize

vq = VectorQuantize(dim=512,
                    codebook_size=32,
                    codebook_dim=512,
                    heads=1,
                    ema_update=False,
                    learnable_codebook=True,
                    in_place_codebook_optimizer=lambda *args, **kwargs: SGD(*args, **kwargs, lr=50.0),
                )

x = torch.rand(7, 1, 512, requires_grad=True)

for _ in range(10):
    *_, loss = vq(x)

    print(loss) # This will decrease over time as the vq._codebook.embed is updated
```

Another possibility to get the learnable codebook to work would be for the VectorQuantizer to return a codebook commit loss, which would be some sort of distance like this `((x.detach() - quantize)**2).mean()`. This would not be as efficient because you'd have to pass it through the project_in and project_out an extra time for every in-place update.