### PR TITLE
detach buffer before registering

### DIFF
--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -332,10 +332,10 @@ class EuclideanCodebook(nn.Module):
         old_value = getattr(self, buffer_name)
 
         if not exists(old_value):
-            self.register_buffer(buffer_name, new_value)
+            self.register_buffer(buffer_name, new_value.detach())
             return
 
-        value = old_value * decay + new_value * (1 - decay)
+        value = old_value * decay + new_value.detach() * (1 - decay)
         self.register_buffer(buffer_name, value)
 
     @torch.jit.ignore


### PR DESCRIPTION
The affine parameters were remaining attached to the grad graph through the learnable codebook, and then being saved as buffers with the grad attached. Since the ema update uses a recursive formula that references the old values, the gradients for the affine parameter buffers were never being dropped. After a while this would cause OOM, if you were using a VQ with learnable codebook and affine param

This commit detaches tensors before saving them as a buffer, and makes sure that no tensors being saved as buffers have any attached grads