### PR TITLE
fix sd loading, don't update affine during eval

### DIFF
--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -304,8 +304,10 @@ class EuclideanCodebook(nn.Module):
         self.register_buffer('batch_mean', None)
         self.register_buffer('batch_variance', None)
 
-        self.register_buffer('codebook_mean', None)
-        self.register_buffer('codebook_variance', None)
+        self.register_buffer('codebook_mean_needs_init', torch.Tensor([True]))
+        self.register_buffer('codebook_mean', torch.empty(num_codebooks, 1, dim))
+        self.register_buffer('codebook_variance_needs_init', torch.Tensor([True]))
+        self.register_buffer('codebook_variance', torch.empty(num_codebooks, 1, dim))
 
     @torch.jit.ignore
     def init_embed_(self, data):
@@ -329,8 +331,14 @@ class EuclideanCodebook(nn.Module):
     def update_with_decay(self, buffer_name, new_value, decay):
         old_value = getattr(self, buffer_name)
 
-        if not exists(old_value):
+        needs_init = getattr(self, buffer_name + "_needs_init", False)
+
+        if needs_init:
+            self.register_buffer(buffer_name + "_needs_init", torch.Tensor([False]))
+
+        if not exists(old_value) or needs_init:
             self.register_buffer(buffer_name, new_value.detach())
+
             return
 
         value = old_value * decay + new_value.detach() * (1 - decay)
@@ -419,7 +427,7 @@ class EuclideanCodebook(nn.Module):
 
         self.init_embed_(flatten)
 
-        if self.affine_param:
+        if self.affine_param and self.training:
             self.update_affine(flatten, self.embed)
 
         embed = self.embed if self.learnable_codebook else self.embed.detach()

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -352,8 +352,9 @@ class EuclideanCodebook(nn.Module):
 
         data, embed = map(lambda t: rearrange(t, 'h ... d -> h (...) d'), (data, embed))
 
-        self.update_with_decay('codebook_mean', reduce(embed, 'h n d -> h 1 d', 'mean'), self.affine_param_codebook_decay)
-        self.update_with_decay('codebook_variance', reduce(embed, 'h n d -> h 1 d', var_fn), self.affine_param_codebook_decay)
+        if self.training:
+            self.update_with_decay('codebook_mean', reduce(embed, 'h n d -> h 1 d', 'mean'), self.affine_param_codebook_decay)
+            self.update_with_decay('codebook_variance', reduce(embed, 'h n d -> h 1 d', var_fn), self.affine_param_codebook_decay)
 
         if not self.sync_affine_param:
             self.update_with_decay('batch_mean', reduce(data, 'h n d -> h 1 d', 'mean'), self.affine_param_batch_decay)
@@ -427,7 +428,7 @@ class EuclideanCodebook(nn.Module):
 
         self.init_embed_(flatten)
 
-        if self.affine_param and self.training:
+        if self.affine_param:
             self.update_affine(flatten, self.embed)
 
         embed = self.embed if self.learnable_codebook else self.embed.detach()


### PR DESCRIPTION
This is related to https://github.com/pytorch/pytorch/issues/8104

previously, the affine params were not loadable from state dict, because they are initialized in the constructor as None

```python
import torch
from vector_quantize_pytorch import VectorQuantize

vq = VectorQuantize(512, 32, affine_param=True, learnable_codebook=True, ema_update=False)

vq(torch.randn(1,512))

assert vq._codebook.codebook_mean is not None

torch.save(vq.state_dict(), "sd.pt")

vq_loaded = VectorQuantize(512, 32, affine_param=True, learnable_codebook=True, ema_update=False)

# If not using strict mode, you'd get:
#  Unexpected key(s) in state_dict: "_codebook.batch_mean", "_codebook.batch_variance", .....
vq_loaded.load_state_dict(torch.load("sd.pt"), strict=False) 
```

To get around this I initialized the buffers with empty tensors, and added ..._needs_init buffers that determine whether the affine buffers should be updated with ema, or just initialized.