### PR TITLE
put bits on the weight's device

### DIFF
--- a/vector_quantize_pytorch/lookup_free_quantization.py
+++ b/vector_quantize_pytorch/lookup_free_quantization.py
@@ -132,7 +132,7 @@ class LFQ(Module):
 
         # indices to codes, which are bits of either -1 or 1
 
-        bits = ((indices[..., None].int() & self.mask) != 0).float()
+        bits = ((indices[..., None].int() & self.mask) != 0).to(self.project_out.weight.dtype)
         codes = bits * 2 - 1
 
         codes = rearrange(codes, '... c d -> ... (c d)')


### PR DESCRIPTION
I've been playing around with LFQ, it works pretty well, even on half precision.

There's also a cast to float32 in the main vector quantize class [here](https://github.com/lucidrains/vector-quantize-pytorch/blob/f90f0ccffcc708b0ec154b15f46507999534a830/vector_quantize_pytorch/vector_quantize_pytorch.py#L447), I'm not sure if that is there because VectorQuantize is unstable at float16. But for LFQ I can say that it works well at float16