### PR TITLE
Update implementation of LFQ with example setups

### DIFF
--- a/examples/autoencoder_fsq.py
+++ b/examples/autoencoder_fsq.py
@@ -28,14 +28,16 @@ class SimpleFSQAutoEncoder(nn.Module):
                 nn.Conv2d(1, 16, kernel_size=3, stride=1, padding=1),
                 nn.MaxPool2d(kernel_size=2, stride=2),
                 nn.GELU(),
-                nn.Conv2d(16, 8, kernel_size=3, stride=1, padding=1),
-                nn.Conv2d(8, 8, kernel_size=6, stride=3, padding=0),
+                nn.Conv2d(16, 32, kernel_size=3, stride=1, padding=1),
+                nn.MaxPool2d(kernel_size=2, stride=2),
+                nn.Conv2d(32, len(levels), kernel_size=1),
                 FSQ(levels),
-                nn.ConvTranspose2d(8, 8, kernel_size=6, stride=3, padding=0),
-                nn.Conv2d(8, 16, kernel_size=4, stride=1, padding=2),
+                nn.Conv2d(len(levels), 32, kernel_size=3, stride=1, padding=1),
+                nn.Upsample(scale_factor=2, mode="nearest"),
+                nn.Conv2d(32, 16, kernel_size=3, stride=1, padding=1),
                 nn.GELU(),
                 nn.Upsample(scale_factor=2, mode="nearest"),
-                nn.Conv2d(16, 1, kernel_size=3, stride=1, padding=2),
+                nn.Conv2d(16, 1, kernel_size=3, stride=1, padding=1),
             ]
         )
         return


### PR DESCRIPTION
In response to #88, I did a full code review of the LFQ implementation, fixed the issues with the entropy loss and updated some hyperparameters. In addition, example scripts are updated to use the same architecture and training recipe as the standard VQ model. A few things to note:

* I only tested with `num_codebooks = 1` or `codebook_scale = 1.` `num_codebooks > 1` may be used as a shortcut for the factorized entropy formulation, but I have never tired Residual LFQ because I think all we need to do is add more bits.
* LFQ is built upon the assumption of the existence of normalization layers in the encoder such as the commonly used ResNet architectures. To this end, I added one `GroupNorm` with `affine=False` in the LFQ example script, which was proved to be important.
* In general we expect higher code active rate (a.k.a utilization) with higher entropy loss weights, but this may on the other hand hurt the reconstruction loss just as in autoencoders vs. VAEs. The benefit is an easier token distribution for the generative model to learn, if the goal is building latent generative models.
* The example script just serves as a verification of the implementation, where the setup (e.g., dataset, resolution, compression ratio, model size) remains minimal and is not designed for a standard comparison.

Test run results (each for 1k steps in ~36 seconds):

|     | Entropy loss weight | Rec loss |  Active | Cmt loss | Entropy+Cmt loss |
|:---:|:-------------------:|:--------:|:-------:|:--------:|:----------------:|
|  VQ |                     |   0.122  | 21.875% |   0.001  |                  |
| FSQ |                     |   0.114  | 80.000% |          |                  |
| LFQ |          0          |   0.129  |  5.859% |          |       0.030      |
| LFQ |         0.01        |   0.117  | 24.609% |          |       0.005      |
| LFQ |         0.02        |   0.116  | 82.031% |          |      -0.035      |
| LFQ |         0.03        |   0.120  | 91.797% |          |      -0.085      |
| LFQ |         0.04        |   0.123  | 99.219% |          |      -0.140      |