### PR TITLE
cast for bf16 issue

### DIFF
--- a/vector_quantize_pytorch/lookup_free_quantization.py
+++ b/vector_quantize_pytorch/lookup_free_quantization.py
@@ -217,7 +217,7 @@ class LFQ(Module):
 
         if self.training:
             # the same as euclidean distance up to a constant
-            distance = -2 * einsum('... i d, j d -> ... i j', original_input, self.codebook)
+            distance = -2 * einsum('... i d, j d -> ... i j', original_input, self.codebook.to(original_input))
 
             prob = (-distance * inv_temperature).softmax(dim = -1)
 


### PR DESCRIPTION
Current version under bf16 training will tiger the following mismatched type error in einsum.

```  
File "/opt/conda/lib/python3.10/site-packages/vector_quantize_pytorch/lookup_free_quantization.py", line 220, in forward
    distance = -2 * einsum('... i d, j d -> ... i j', original_input, self.codebook)
  File "/opt/conda/lib/python3.10/site-packages/torch/functional.py", line 377, in einsum
    return _VF.einsum(equation, operands)  # type: ignore[attr-defined]
RuntimeError: expected scalar type Float but found BFloat16
```

 Add an explicit cast to solve it. 

Actually it should be covered by the autocast mechanism of pytorch. But somehow the autocast does not work as expected. There might exist a more elegant fix to directly trigger the autocast. 