### PR TITLE
Fix 1e7 in random.randint

### DIFF
--- a/vector_quantize_pytorch/residual_fsq.py
+++ b/vector_quantize_pytorch/residual_fsq.py
@@ -262,7 +262,7 @@ class GroupedResidualFSQ(Module):
 
         forward_kwargs = dict(
             return_all_codes = return_all_codes,
-            rand_quantize_dropout_fixed_seed = random.randint(0, 1e7)
+            rand_quantize_dropout_fixed_seed = random.randint(0, 10_000_000)
         )
 
         # invoke residual vq on each group


### PR DESCRIPTION
This PR fixed issue in Python 3.12, which randrange will throw an exception if the input is not an int.

The bug was originally reported in downstream repo fish-speech:

https://github.com/fishaudio/fish-speech/issues/215#issuecomment-2115614074