### PR TITLE
Support half precision for VQ and FSQ

### DIFF
--- a/vector_quantize_pytorch/residual_fsq.py
+++ b/vector_quantize_pytorch/residual_fsq.py
@@ -146,7 +146,7 @@ class ResidualFSQ(Module):
         x = self.project_in(x)
 
         quantized_out = 0.
-        residual = first(self.layers).bound(x)
+        residual = first(self.layers).bound(x).to(x.dtype)
 
         all_indices = []
 

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -478,7 +478,7 @@ class EuclideanCodebook(Module):
         needs_codebook_dim = x.ndim < 4
         sample_codebook_temp = default(sample_codebook_temp, self.sample_codebook_temp)
 
-        x = x.float()
+        # x = x.float() removed for other precision
 
         if needs_codebook_dim:
             x = rearrange(x, '... -> 1 ...')
@@ -668,7 +668,7 @@ class CosineSimCodebook(Module):
         needs_codebook_dim = x.ndim < 4
         sample_codebook_temp = default(sample_codebook_temp, self.sample_codebook_temp)
 
-        x = x.float()
+        # x = x.float() removed for other precision
 
         if needs_codebook_dim:
             x = rearrange(x, '... -> 1 ...')


### PR DESCRIPTION
Hi, I notice it is not support other preicsion. I made this tiny change and I tried a simple sample and it works on fp16 and bf16.
I noticed that there is a x = x.float(), I just comment it. I don't know if it is necessary. In my experiment, it just works fine, we can choose any precision into it.