### PR TITLE
Added access to codebook_size and codebook_dim as properties in ResidualVQ

### DIFF
--- a/vector_quantize_pytorch/residual_vq.py
+++ b/vector_quantize_pytorch/residual_vq.py
@@ -84,6 +84,14 @@ class ResidualVQ(Module):
 
         for vq in rest_vq:
             vq._codebook = codebook
+    
+    @property
+    def codebook_size(self):
+        return self.layers[0].codebook_size
+    
+    @property
+    def codebook_dim(self):
+        return self.layers[0].codebook_dim
 
     @property
     def codebooks(self):


### PR DESCRIPTION
It is useful to have these properties available directly, as opposed to making the user access the layers to gather that information.