### PR TITLE
update autocast

### DIFF
--- a/vector_quantize_pytorch/finite_scalar_quantization.py
+++ b/vector_quantize_pytorch/finite_scalar_quantization.py
@@ -12,7 +12,6 @@ import torch
 import torch.nn as nn
 from torch.nn import Module
 from torch import Tensor, int32
-from torch.cuda.amp import autocast
 
 from einops import rearrange, pack, unpack
 
@@ -159,7 +158,7 @@ class FSQ(Module):
 
         return codes
 
-    @autocast(enabled = False)
+    @torch.amp.autocast('cuda', enabled = False)
     def forward(self, z):
         """
         einstein notation

--- a/vector_quantize_pytorch/lookup_free_quantization.py
+++ b/vector_quantize_pytorch/lookup_free_quantization.py
@@ -16,7 +16,6 @@ import torch
 from torch import nn, einsum
 import torch.nn.functional as F
 from torch.nn import Module
-from torch.cuda.amp import autocast
 
 from einops import rearrange, reduce, pack, unpack
 
@@ -293,9 +292,9 @@ class LFQ(Module):
 
         force_f32 = self.force_quantization_f32
 
-        quantization_context = partial(autocast, enabled = False) if force_f32 else nullcontext
+        quantization_context = partial(torch.amp.autocast, enabled = False) if force_f32 else nullcontext
 
-        with quantization_context():
+        with quantization_context('cuda'):
 
             if force_f32:
                 orig_dtype = x.dtype

--- a/vector_quantize_pytorch/residual_fsq.py
+++ b/vector_quantize_pytorch/residual_fsq.py
@@ -8,7 +8,6 @@ import torch
 from torch import nn
 from torch.nn import Module, ModuleList
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
 
 from vector_quantize_pytorch.finite_scalar_quantization import FSQ
 
@@ -167,7 +166,7 @@ class ResidualFSQ(Module):
 
         # go through the layers
 
-        with autocast(enabled = False):
+        with torch.amp.autocast('cuda', enabled = False):
             for quantizer_index, (layer, scale) in enumerate(zip(self.layers, self.scales)):
 
                 if should_quantize_dropout and quantizer_index > rand_quantize_dropout_index:

--- a/vector_quantize_pytorch/residual_lfq.py
+++ b/vector_quantize_pytorch/residual_lfq.py
@@ -6,7 +6,6 @@ import torch
 from torch import nn
 from torch.nn import Module, ModuleList
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
 
 from vector_quantize_pytorch.lookup_free_quantization import LFQ
 
@@ -156,7 +155,7 @@ class ResidualLFQ(Module):
 
         # go through the layers
 
-        with autocast(enabled = False):
+        with torch.amp.autocast('cuda', enabled = False):
             for quantizer_index, layer in enumerate(self.layers):
 
                 if should_quantize_dropout and quantizer_index > rand_quantize_dropout_index:

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -7,7 +7,6 @@ from torch import nn, einsum, Tensor
 import torch.nn.functional as F
 import torch.distributed as distributed
 from torch.optim import Optimizer
-from torch.cuda.amp import autocast
 
 import einx
 from einops import rearrange, repeat, reduce, pack, unpack
@@ -459,7 +458,7 @@ class EuclideanCodebook(Module):
         batch_samples = rearrange(batch_samples, 'h ... d -> h (...) d')
         self.replace(batch_samples, batch_mask = expired_codes)
 
-    @autocast(enabled = False)
+    @torch.amp.autocast('cuda', enabled = False)
     def forward(
         self,
         x,
@@ -644,7 +643,7 @@ class CosineSimCodebook(Module):
         batch_samples = rearrange(batch_samples, 'h ... d -> h (...) d')
         self.replace(batch_samples, batch_mask = expired_codes)
 
-    @autocast(enabled = False)
+    @torch.amp.autocast('cuda', enabled = False)
     def forward(
         self,
         x,


### PR DESCRIPTION
from torch: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.