### PR TITLE
Remove double l2 normalization

### DIFF
--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -751,7 +751,7 @@ class CosineSimCodebook(Module):
             embed_normalized = self.embed_avg / rearrange(cluster_size, '... -> ... 1')
             embed_normalized = l2norm(embed_normalized)
 
-            self.embed.data.copy_(l2norm(embed_normalized))
+            self.embed.data.copy_(embed_normalized)
             self.expire_codes_(x)
 
         if needs_codebook_dim:


### PR DESCRIPTION
Subsequent l2 normalizations do not change the output vector - I'm guessing it was left by mistake.