### PR TITLE
Add symmetry-preserving and noise-approximated quantization for FSQ from arxiv:2411.19842

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -219,11 +219,14 @@ def test_tiger():
 
     assert torch.allclose(quantized, quantized_out, atol = 1e-5)
 
-def test_fsq():
+@pytest.mark.parametrize('preserve_symmetry', (True, False))
+def test_fsq(
+    preserve_symmetry
+):
     from vector_quantize_pytorch import FSQ
 
     levels = [8,5,5,5] # see 4.1 and A.4.1 in the paper
-    quantizer = FSQ(levels)
+    quantizer = FSQ(levels, preserve_symmetry = preserve_symmetry)
 
     x = torch.randn(1, 1024, 4) # 4 since there are 4 levels
     xhat, indices = quantizer(x)


### PR DESCRIPTION
This adds a variant of FSQ from [this paper](https://arxiv.org/pdf/2411.19842) which uses a different formulation for the quantization function.

It also allows approximating quantization using noise during training at a particular probability, which the paper uses as a kind of "quantization dropout" regularization during training.

I added tests and it looks ok to me from running a few samples, but I haven't extensively trained with this yet, fwiw.

The section from the paper:

<img width="769" alt="Screenshot 2025-01-02 at 10 37 08 AM" src="https://github.com/user-attachments/assets/ed2138c7-b869-4c88-9178-d2035e653a1c" />
