### PR TITLE
Compute commit loss before aux loss and input changes

### DIFF
--- a/vector_quantize_pytorch/lookup_free_quantization.py
+++ b/vector_quantize_pytorch/lookup_free_quantization.py
@@ -326,6 +326,20 @@ class LFQ(Module):
             else:
                 x = quantized
 
+            # commit loss
+
+            if self.training and self.commitment_loss_weight > 0.:
+
+                commit_loss = F.mse_loss(original_input, quantized.detach(), reduction = 'none')
+
+                if exists(mask):
+                    commit_loss = commit_loss[mask]
+
+                commit_loss = commit_loss.mean()
+            else:
+                commit_loss = self.zero
+
+
             # entropy aux loss
 
             if self.training:
@@ -389,19 +403,6 @@ class LFQ(Module):
 
             if self.training and self.experimental_softplus_entropy_loss:
                 entropy_aux_loss = F.softplus(entropy_aux_loss + self.entropy_loss_offset)
-
-            # commit loss
-
-            if self.training and self.commitment_loss_weight > 0.:
-
-                commit_loss = F.mse_loss(original_input, quantized.detach(), reduction = 'none')
-
-                if exists(mask):
-                    commit_loss = commit_loss[mask]
-
-                commit_loss = commit_loss.mean()
-            else:
-                commit_loss = self.zero
 
             # input back to original dtype if needed
 


### PR DESCRIPTION
This PR addresses #188 by computing the LFQ commit loss before the `original_input` is masked and reshaped. I have tested these changes using with the `MeshAutoencoderTrainer` from [meshgpt-pytorch](https://github.com/MarcusLoppe/meshgpt-pytorch) which was previously broken by this problem. I confirmed that this quick-fix results in correct commit loss computations and that the forward pass doesn't break with `commitment_loss_weight = 0.0` and `commitment_loss_weight > 0`.