### PR TITLE
Fix 'ceil' is not defined

### DIFF
--- a/vector_quantize_pytorch/residual_fsq.py
+++ b/vector_quantize_pytorch/residual_fsq.py
@@ -1,5 +1,5 @@
 import random
-from math import log2
+from math import ceil
 from functools import partial
 
 from typing import List

--- a/vector_quantize_pytorch/residual_lfq.py
+++ b/vector_quantize_pytorch/residual_lfq.py
@@ -1,5 +1,5 @@
 import random
-from math import log2
+from math import ceil, log2
 from functools import partial, cache
 
 import torch


### PR DESCRIPTION
When using ResidualFSQ, this error occurs:
```
  File "(path removed)/lib/python3.12/site-packages/vector_quantize_pytorch/residual_fsq.py", line 32, in round_up_multiple
    return ceil(num / mult) * mult
           ^^^^
NameError: name 'ceil' is not defined
```
