### PR TITLE
fix: skip round+normalize when preserve_symmetry=True (already in [-1…

### DIFF
--- a/vector_quantize_pytorch/finite_scalar_quantization.py
+++ b/vector_quantize_pytorch/finite_scalar_quantization.py
@@ -151,6 +151,9 @@ class FSQ(Module):
             offset = torch.rand_like(bounded_z) - 0.5
             bounded_z = torch.where(offset_mask, bounded_z + offset, bounded_z)
 
+        if preserve_symmetry:
+            return bounded_z
+        
         return round_ste(bounded_z) / half_width
 
     def _scale_and_shift(self, zhat_normalized):


### PR DESCRIPTION
When preserve_symmetry=True, symmetry_preserving_bound already produces
the L discrete codes in [-1,1]. Won't the subsequent steps collapse them to just {-1,0,1}?