### PR TITLE
GaussianQuant: VQ-VAE using Gaussian VAE

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,32 @@ assert indices.shape == (2, 3, num_codebooks)
 assert loss.item() >= 0
 ```
 
+## GaussianQuant
+* Train a Gaussian VAE and convert it into VQ-VAE without much loss. 
+* The Gaussian VAE need to satisfy $D_{KL}(q(Z^i|X)||N(0,1))\approx\log_2$ codebooksize.
+* The GaussianQuant has exact same interface as VQ-VAE. You can determine codebook dim, codebook size, and GaussianQuant will implicitly infer codebook number.
+* The GaussianQuant takes input of any shape. But you need to specify which dimension to quantize.
+* Unlike other VQ-VAE, the input Z should contains twice channels, the first split is mean of Gaussian VAE, the second split is the logvar.
+* For details, see https://github.com/tongdaxu/VQ-VAE-from-Gaussian-VAE
+* Usage example can be found in ./examples/autoencoder_gq.py
+* Usage example can also be found below:
+```python
+    import torch
+    from vector_quantize_pytorch import GaussianQuant
+    mu = torch.zeros([1,6,64,64]) # B, C, H, W,
+    logvar = torch.zeros([1,6,64,64])
+    input = torch.cat([mu, logvar],dim=1)
+    gq = GaussianQuant(dim=3, dim_idx=1, codebook_size=128)
+    # quant on C dimension
+    # codebook dim = 3, input dim = 6, so codebook number is 2
+    zhat, log = gq(input)
+    loss = log["kl-loss"]
+
+    indices = log["indices"]
+    print(indices.shaoe)
+    zhat2 = gq.indices_to_codes(indices)
+```
+
 ## Citations
 
 ```bibtex

--- a/examples/autoencoder_gq.py
+++ b/examples/autoencoder_gq.py
@@ -1,0 +1,81 @@
+# FashionMnist VQ experiment with various settings.
+# From https://github.com/minyoungg/vqtorch/blob/main/examples/autoencoder.py
+
+from tqdm.auto import trange
+
+import torch
+import torch.nn as nn
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+
+from vector_quantize_pytorch import GaussianQuant, Sequential
+
+lr = 3e-4
+train_iter = 5000
+num_codes = 256
+seed = 1234
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+def SimpleVQAutoEncoder():
+    return Sequential(
+        nn.Conv2d(1, 16, kernel_size=3, stride=1, padding=1),
+        nn.MaxPool2d(kernel_size=2, stride=2),
+        nn.GELU(),
+        nn.Conv2d(16, 64, kernel_size=3, stride=1, padding=1),
+        nn.MaxPool2d(kernel_size=2, stride=2),
+        GaussianQuant(dim=32, dim_idx=1, codebook_size=num_codes),
+        nn.Upsample(scale_factor=2, mode="nearest"),
+        nn.Conv2d(32, 16, kernel_size=3, stride=1, padding=1),
+        nn.GELU(),
+        nn.Upsample(scale_factor=2, mode="nearest"),
+        nn.Conv2d(16, 1, kernel_size=3, stride=1, padding=1),
+    )
+
+def train(model, train_loader, train_iterations=1000, alpha=1e-7):
+    def iterate_dataset(data_loader):
+        data_iter = iter(data_loader)
+        while True:
+            try:
+                x, y = next(data_iter)
+            except StopIteration:
+                data_iter = iter(data_loader)
+                x, y = next(data_iter)
+            yield x.to(device), y.to(device)
+
+    for _ in (pbar := trange(train_iterations)):
+        opt.zero_grad()
+        x, _ = next(iterate_dataset(train_loader))
+
+        out, log = model(x)
+        out = out.clamp(-1., 1.)
+
+        kl_loss = log["kl-loss"]
+        indices = log["indices"]
+
+        rec_loss = (out - x).abs().mean()
+        (rec_loss + alpha * kl_loss).backward()
+
+        opt.step()
+        pbar.set_description(
+            f"rec loss VQ: {rec_loss.item():.3f} | "
+            f"kl loss: {kl_loss.item():.3f} | "
+            + f"active %: {indices.unique().numel() / num_codes * 100:.3f}"
+        )
+
+transform = transforms.Compose(
+    [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
+)
+train_dataset = DataLoader(
+    datasets.FashionMNIST(
+        root="~/data/fashion_mnist", train=True, download=True, transform=transform
+    ),
+    batch_size=256,
+    shuffle=True,
+)
+
+torch.random.manual_seed(seed)
+
+model = SimpleVQAutoEncoder().to(device)
+
+opt = torch.optim.AdamW(model.parameters(), lr=lr)
+train(model, train_dataset, train_iterations=train_iter)

--- a/vector_quantize_pytorch/__init__.py
+++ b/vector_quantize_pytorch/__init__.py
@@ -6,6 +6,7 @@ from vector_quantize_pytorch.lookup_free_quantization import LFQ
 from vector_quantize_pytorch.residual_lfq import ResidualLFQ, GroupedResidualLFQ
 from vector_quantize_pytorch.residual_fsq import ResidualFSQ, GroupedResidualFSQ
 from vector_quantize_pytorch.latent_quantization import LatentQuantize
+from vector_quantize_pytorch.gaussian_quant import GaussianQuant
 
 from vector_quantize_pytorch.sim_vq import SimVQ
 from vector_quantize_pytorch.residual_sim_vq import ResidualSimVQ

--- a/vector_quantize_pytorch/gaussian_quant.py
+++ b/vector_quantize_pytorch/gaussian_quant.py
@@ -1,0 +1,198 @@
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+from torch.quasirandom import SobolEngine
+from scipy.stats import norm
+import math
+
+def prior_samples(n_samples, n_variable, seed_rec):
+    sobol = SobolEngine(n_variable, scramble=True, seed=seed_rec)
+    samples_sobol = sobol.draw(n_samples)
+    samples_i = torch.from_numpy(norm.ppf(samples_sobol))
+    return samples_i
+
+class GaussianQuant(nn.Module):
+    def __init__(self, dim, dim_idx, codebook_size, logvar_range=[-30.0, 20.0], # common parameters
+                 tolerance = 0.5, lam_factor=1.01, # train parameters
+                 seed=42, beta=1.0, use_ste=True):
+        super().__init__()
+        self.dim_idx = dim_idx
+        self.dim = dim
+        self.logvar_range = logvar_range
+        self.n_samples = codebook_size
+        self.log_n_samples = int(math.log(self.n_samples, 2))
+        # training parameter setup
+        self.lam_factor = lam_factor
+        self.lam = 1.0
+        self.lam_min = 1.0
+        self.lam_max = 1.0
+        self.lam_range = (1e-7, 1e7)
+        self.tolerance = tolerance
+
+        # inference parameter setup
+        self.beta = beta
+        self.seed = seed
+        self.register_buffer("prior_samples", prior_samples(self.n_samples, self.dim, self.seed).float(), persistent=False)
+        self.normal_dist = Normal(torch.zeros([1, self.dim]), torch.ones([1, self.dim]))
+        self.register_buffer("normal_log_prob", self.normal_dist.log_prob(self.prior_samples).float(), persistent=False)
+
+        self.logvar_range = logvar_range
+        self.use_ste = use_ste
+        self.perturbed = None
+
+    def quant_gaussian(self, z):
+        z = torch.movedim(z, self.dim_idx, -1)
+        assert(z.shape[-1] % (self.dim * 2) == 0)
+        z_shape = z.shape
+        z = z.reshape(-1, z_shape[-1])
+        codebook_num=z.shape[-1] // (self.dim * 2)
+        # get \mu and \sigma 
+        mu, logvar = z.chunk(2, -1)
+        logvar = torch.clamp(logvar, self.logvar_range[0], self.logvar_range[1])
+        std = torch.exp(0.5 * logvar)
+        var = torch.exp(logvar)
+
+        # Gaussian VAE
+        zhat = mu + torch.randn_like(mu) * std
+        # kl divergence in log 2
+        kl2 = 1.4426 * 0.5 * (torch.pow(mu, 2) + var - 1.0 - logvar)
+        # -1, dim, codebook number
+        kl2 = kl2.reshape(-1,self.dim,codebook_num)
+        kl2 = torch.sum(kl2,dim=1) # sum over dim
+
+        # compute mean, min, max of kl divergence
+        kl2_mean, kl2_min, kl2_max = torch.mean(kl2), torch.min(kl2), torch.max(kl2)
+        ge = (kl2 > self.log_n_samples + self.tolerance).type(kl2.dtype) * self.lam_max
+        eq = (kl2 <= self.log_n_samples + self.tolerance).type(kl2.dtype) * (
+            kl2 >= self.log_n_samples - self.tolerance
+        ).type(kl2.dtype)
+        le = (kl2 < self.log_n_samples - self.tolerance).type(kl2.dtype) * self.lam_min
+
+        # reweight kl divergence according to its relation to log2 codebook_size
+        kl_loss = ge * kl2 + eq * kl2 + le * kl2
+        kl_loss = torch.mean(kl_loss) * self.lam
+        # update lambda
+        if kl2_mean > self.log_n_samples:
+            self.lam = self.lam * self.lam_factor
+        else:
+            self.lam = self.lam / self.lam_factor
+
+        if kl2_max > self.log_n_samples + self.tolerance:
+            self.lam_max = self.lam_max * self.lam_factor
+        else:
+            self.lam_max / self.lam_max * self.lam_factor
+        self.lam_max = max(min(self.lam_max, self.lam_range[1]), 1.0)
+        if kl2_min < self.log_n_samples - self.tolerance:
+            self.lam_min = self.lam_min / self.lam_factor
+        else:
+            self.lam_min = self.lam_min * self.lam_factor
+        self.lam_min = max(min(self.lam_min, 1.0), self.lam_range[0])
+
+        zhat = zhat.reshape(*z_shape[:-1], -1)
+        zhat = torch.movedim(zhat, -1, self.dim_idx)
+
+        mu = mu.reshape(*z_shape[:-1], -1)
+        mu = torch.movedim(mu, -1, self.dim_idx)
+
+        std = std.reshape(*z_shape[:-1], -1)
+        std = torch.movedim(std, -1, self.dim_idx)
+
+        info = {"kl-loss": torch.mean(kl_loss), "bits-mean": kl2_mean, "bits-min": kl2_min, "bits-max": kl2_max, 
+                "lam-min": self.lam_min, "lam-max": self.lam_max, "lam": self.lam, "mu": mu, "std": std, "zhat_noquant": zhat}
+
+        return zhat, info
+
+    def quant_vq(self, z):
+
+        # reshape to (-1, dim * codebook_num)
+        z = torch.movedim(z, self.dim_idx, -1)
+        assert(z.shape[-1] % (self.dim * 2) == 0)
+        z_shape = z.shape
+        z = z.reshape(-1, z_shape[-1])
+        codebook_num=z.shape[-1] // (self.dim * 2)
+        # get \mu and \sigma 
+        mu, logvar = z.chunk(2, -1)
+        logvar = torch.clamp(logvar, self.logvar_range[0], self.logvar_range[1])
+        std = torch.exp(0.5 * logvar)
+
+        # reshape everything into (-1, dim)
+        mu = mu.reshape(-1,self.dim,codebook_num).permute(0,2,1).reshape(-1,self.dim)
+        std = std.reshape(-1,self.dim,codebook_num).permute(0,2,1).reshape(-1,self.dim)
+
+        # process per batch to avoid OOM
+        bs = mu.shape[0] // 8
+        zhat = torch.zeros_like(mu)
+        indices = torch.zeros([mu.shape[0]], device=mu.device, dtype=torch.long)
+        for i in range(0, mu.shape[0], bs):
+            mu_q = mu[i:i+bs]
+            std_q = std[i:i+bs]
+            q_normal_dist = Normal(mu_q[:, None, :], std_q[:, None, :])
+            log_ratios = (
+                q_normal_dist.log_prob(self.prior_samples[None])
+                - self.normal_log_prob[None] * self.beta
+            )
+            perturbed = torch.sum(log_ratios, dim=2)
+            argmax_indices = torch.argmax(perturbed, dim=1)
+            zhat[i:i+bs] = torch.index_select(self.prior_samples, 0, argmax_indices)
+            indices[i:i+bs] = argmax_indices
+        zhat = zhat.reshape(-1,codebook_num,self.dim).permute(0,2,1).reshape(-1,codebook_num*self.dim).float()
+        indices = indices.reshape(-1,codebook_num)
+
+        zhat = zhat.reshape(*z_shape[:-1], -1)
+        zhat = torch.movedim(zhat, -1, self.dim_idx)
+
+        indices = indices.reshape(*z_shape[:-1], -1)
+        indices = torch.movedim(indices, -1, self.dim_idx)
+
+        info = {"indices": indices, "zhat_quant": zhat}
+
+        return zhat, info
+
+    def forward(self, z):
+        zhat_g, info_g = self.quant_gaussian(z)
+        with torch.no_grad():
+            zhat_v, info_v = self.quant_vq(z)
+        if self.use_ste:
+            zhat = zhat_g - zhat_g.detach() + zhat_v
+        else:
+            if self.training:
+                zhat = zhat_g
+            else:
+                zhat = zhat_v
+        info = info_g | info_v
+        return zhat, info
+
+    def indices_to_codes(
+        self,
+        indices
+    ):
+        indices = torch.movedim(indices, self.dim_idx, -1)
+        i_shape = indices.shape
+        codebook_num = i_shape[-1]
+        indices = indices.reshape(-1)
+        zhat = torch.zeros([indices.shape[0], self.dim], device=indices.device, dtype=torch.float32)
+        zhat = torch.index_select(self.prior_samples, 0, indices).float()
+        zhat = zhat.reshape(-1,codebook_num,self.dim).permute(0,2,1).reshape(-1,codebook_num*self.dim)
+
+        # back to original shape
+        zhat = zhat.reshape(*i_shape[:-1], -1)
+        zhat = torch.movedim(zhat, -1, self.dim_idx)
+        return zhat
+
+
+if __name__ == "__main__":
+    mu = torch.zeros([1,6,64,64])
+    logvar = torch.zeros([1,6,64,64])
+    input = torch.cat([mu, logvar],dim=1)
+    gq = GaussianQuant(dim=3, dim_idx=1, codebook_size=128)
+    gq.train()
+    zhat, log = gq(input)
+    loss = log["kl-loss"]
+
+    gq.eval()
+    zhat_vq, log = gq(input)
+    indices = log["indices"]
+    zhat2 = gq.indices_to_codes(indices)
+    print(torch.sum(torch.abs(zhat_vq - zhat2)))
+    print(torch.mean(torch.abs(zhat_vq - mu)))
+    print(torch.mean(torch.abs(log["zhat_noquant"] - mu)))

--- a/vector_quantize_pytorch/utils.py
+++ b/vector_quantize_pytorch/utils.py
@@ -14,6 +14,7 @@ from vector_quantize_pytorch.residual_fsq import ResidualFSQ, GroupedResidualFSQ
 from vector_quantize_pytorch.latent_quantization import LatentQuantize
 from vector_quantize_pytorch.sim_vq import SimVQ
 from vector_quantize_pytorch.residual_sim_vq import ResidualSimVQ
+from vector_quantize_pytorch.gaussian_quant import GaussianQuant
 
 QUANTIZE_KLASSES = (
     VectorQuantize,
@@ -28,7 +29,8 @@ QUANTIZE_KLASSES = (
     GroupedResidualLFQ,
     ResidualFSQ,
     GroupedResidualFSQ,
-    LatentQuantize
+    LatentQuantize,
+    GaussianQuant
 )
 
 # classes


### PR DESCRIPTION
## GaussianQuant: VQ-VAE using Gaussian VAE
* Conceptually:
  * Train a Gaussian VAE and convert it into VQ-VAE without much loss!
  * The Gaussian VAE need to satisfy $D_{KL}(q(Z^i|X)||N(0,1))\approx\log_2$ codebooksize. This is achieved by special designed loss for KL divergence. See details in gaussian_quant.py:
    ```python
    kl2 = 1.4426 * 0.5 * (torch.pow(mu, 2) + var - 1.0 - logvar)
    # -1, dim, codebook number
    kl2 = kl2.reshape(-1,self.dim,codebook_num)
    kl2 = torch.sum(kl2,dim=1) # sum over dim
  
    # compute mean, min, max of kl divergence
    kl2_mean, kl2_min, kl2_max = torch.mean(kl2), torch.min(kl2), torch.max(kl2)
    ge = (kl2 > self.log_n_samples + self.tolerance).type(kl2.dtype) * self.lam_max
    eq = (kl2 <= self.log_n_samples + self.tolerance).type(kl2.dtype) * (
        kl2 >= self.log_n_samples - self.tolerance
    ).type(kl2.dtype)
    le = (kl2 < self.log_n_samples - self.tolerance).type(kl2.dtype) * self.lam_min
  
    # reweight kl divergence according to its relation to log2 codebook_size
    kl_loss = ge * kl2 + eq * kl2 + le * kl2
    kl_loss = torch.mean(kl_loss) * self.lam
    ```
  * The codebook vector is purely Gaussian noise. The codebook is not updated. During inference, we just find the noise vector closest to mu:
    ```python
    q_normal_dist = Normal(mu_q[:, None, :], std_q[:, None, :])
    log_ratios = (
        q_normal_dist.log_prob(self.prior_samples[None])
        - self.normal_log_prob[None] * self.beta
    )
    perturbed = torch.sum(log_ratios, dim=2)
    argmax_indices = torch.argmax(perturbed, dim=1)
    zhat[i : i + bs] = torch.index_select(self.prior_samples, 0, argmax_indices)
    indices[i : i + bs] = argmax_indices
    ```
* Practically:
  * The GaussianQuant takes input of any shape. But you need to specify which dimension to quantize.
  * The GaussianQuant has exact same interface as VQ-VAE. You can determine codebook dim, codebook size, and GaussianQuant will implicitly infer codebook number.
  * Unlike other VQ-VAE, the input Z should contains twice channels, the first split is mean of Gaussian VAE, the second split is the logvar.
  * Usage example can be found in ./examples/autoencoder_gq.py
  ```bash 
      python ./examples/autoencoder_gq.py
      # gives: rec loss VQ: 0.121 | kl loss: 352867.281 | active %: 61.328
  ```
  * Usage example can also be found below:
  ```python
      import torch
      from vector_quantize_pytorch import GaussianQuant
      mu = torch.zeros([1,6,64,64]) # B, C, H, W,
      logvar = torch.zeros([1,6,64,64])
      input = torch.cat([mu, logvar],dim=1)
      gq = GaussianQuant(dim=3, dim_idx=1, codebook_size=128)
      # quant on C dimension
      # codebook dim = 3, input dim = 6, so codebook number is 2
      zhat, log = gq(input)
      loss = log["kl-loss"]
      indices = log["indices"]
      print(indices.shape) # (B, codebook number, H, W)
      zhat2 = gq.indices_to_codes(indices)
      print(torch.sum(torch.abs(zhat - zhat2))) # 0
  ```
  * For details, see original repo: https://github.com/tongdaxu/VQ-VAE-from-Gaussian-VAE

