### PR TITLE
Fix implementation and add details on directional reparameterization (DiVeQ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ vq_layer = VectorQuantize(
 )
 ```
 
+Alternatively, the <a href="https://openreview.net/forum?id=KRVnpTbx7R">DiVeQ paper</a> proposes to model quantization as the addition of a simulated quantization error to the input vector. The direction of this simulated error is aligned with the nearest codeword (if ```directional_reparam_variance``` is chosen small), and its magnitude equals the actual quantization error magnitude. In this way, the quantized output becomes a differentiable function of both input vector and selected codeword, and thus, DiVeQ provides valid gradients to learn the codebook without requiring any auxiliary losses. You can enable or disable this feature with ```directional_reparam=True/False``` in the ```VectorQuantize``` class.
+
+```python
+from vector_quantize_pytorch import VectorQuantize
+
+vq_layer = VectorQuantize(
+    dim = 256,
+    codebook_size = 256,
+    directional_reparam = True,   # Set to False to use the STE gradient estimator or True to use the DiVeQ method.
+    directional_reparam_variance = 5e-3
+)
+```
+
 ## Increasing codebook usage
 
 This repository will contain a few techniques from various papers to combat "dead" codebook entries, which is a common problem when using vector quantizers.
@@ -781,14 +794,12 @@ assert loss.item() >= 0
 ```
 
 ```bibtex
-@misc{vali2025diveqdifferentiablevectorquantization,
-    title   = {DiVeQ: Differentiable Vector Quantization Using the Reparameterization Trick},
-    author  = {Mohammad Hassan Vali and Tom Bäckström and Arno Solin},
-    year    = {2025},
-    eprint  = {2509.26469},
-    archivePrefix = {arXiv},
-    primaryClass = {cs.LG},
-    url     = {https://arxiv.org/abs/2509.26469},
+@inproceedings{vali2025diveqdifferentiablevectorquantization,
+    title     = {{DiVeQ}: {D}ifferentiable Vector Quantization Using the Reparameterization Trick},
+    author    = {Mohammad Hassan Vali and Tom Bäckström and Arno Solin},
+    booktitle = {International Conference on Learning Representations (ICLR)},
+    year      = {2026},
+    url       = {https://openreview.net/forum?id=KRVnpTbx7R},
 }
 ```
 

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -608,11 +608,10 @@ class Codebook(Module):
             ema_inplace(self.cluster_size, cluster_size, self.decay, ema_update_weight)
             ema_inplace(self.embed_avg, embed_sum, self.decay, ema_update_weight)
 
-            if not self.manual_ema_update:
+            if not self.manual_ema_update and not self.directional_raparam:
                 self.update_ema()
                 self.expire_codes_(flatten)
-
-            if self.directional_raparam:
+            elif self.directional_raparam:
                 self.expire_codes_(flatten)
 
     def update_ema_indices(

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -314,7 +314,7 @@ def rotate_to(src, tgt):
 
     return inverse(rotated)
 
-# directional reparam related
+# directional reparameterization (DiVeQ) method to learn the codebook
 # figure 1. https://openreview.net/forum?id=KRVnpTbx7R
 
 def directional_reparam(src, tgt, noise_variance = 5e-3):
@@ -324,7 +324,7 @@ def directional_reparam(src, tgt, noise_variance = 5e-3):
     noised_dir = error_dir + sqrt(noise_variance) * torch.randn_like(error_dir)
     unit_noised_dir = l2norm(noised_dir).detach()
 
-    return src + unit_noised_dir * error_dir_norm
+    return src + unit_noised_dir.detach() * error_dir_norm
 
 # distributed helpers
 
@@ -367,7 +367,8 @@ class Codebook(Module):
         affine_param_batch_decay = 0.99,
         affine_param_codebook_decay = 0.9,
         use_cosine_sim = False,
-        vq_bridge: Module | None = None
+        vq_bridge: Module | None = None,
+        directional_raparam: bool | None = None
     ):
         super().__init__()
         self.transform_input = identity if not use_cosine_sim else l2norm
@@ -421,6 +422,9 @@ class Codebook(Module):
         # fvq
 
         self.vq_bridge = vq_bridge
+
+        # DiVeQ method
+        self.directional_raparam = directional_raparam
 
         # affine related params
 
@@ -608,6 +612,9 @@ class Codebook(Module):
                 self.update_ema()
                 self.expire_codes_(flatten)
 
+            if self.directional_raparam:
+                self.expire_codes_(flatten)
+
     def update_ema_indices(
         self,
         x,
@@ -743,7 +750,7 @@ class Codebook(Module):
                 repeated_embed_ind = repeat(embed_ind, 'h b n -> h b n d', d = embed.shape[-1])
                 quantize = repeated_embed.gather(-2, repeated_embed_ind)
 
-        if self.training and ema_update and not freeze_codebook and not exists(topk):
+        if self.training and (ema_update or self.directional_raparam) and not freeze_codebook and not exists(topk):
             self.update_ema_part(flatten, embed_onehot, mask = mask, ema_update_weight = ema_update_weight, accum_ema_update = accum_ema_update)
 
         if needs_codebook_dim:
@@ -902,7 +909,8 @@ class VectorQuantize(Module):
             ema_update = ema_update,
             manual_ema_update = manual_ema_update,
             use_cosine_sim = use_cosine_sim,
-            vq_bridge = vq_bridge
+            vq_bridge = vq_bridge,
+            directional_raparam = directional_reparam
         )
 
         if affine_param:


### PR DESCRIPTION
Fixed detach gradients in the implementation of directional reparameterization (DiVeQ) as explained in the [original publication](https://arxiv.org/pdf/2509.26469). Also, enabled replacing dead codewords by `threshold_ema_dead_code` for the DiVeQ method.

Additionally, added a short description on how to use directional reparameterization (DiVeQ) in the README file.