### PR TITLE
Avoid in-place codebook mask update

### DIFF
--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -588,7 +588,7 @@ class Codebook(Module):
             flatten = (flatten - self.batch_mean) * (codebook_std / batch_std) + self.codebook_mean
 
         if exists(mask):
-            embed_onehot[~mask] = 0.
+            embed_onehot = embed_onehot.masked_fill(~rearrange(mask, '... -> ... 1'), 0.)
 
         cluster_size = embed_onehot.sum(dim = 1)
         self.all_reduce_fn(cluster_size)


### PR DESCRIPTION
## Summary
- Replace the in-place `embed_onehot[~mask] = 0.` update with an out-of-place `masked_fill`.
- Keep the same masked one-hot values before `cluster_size` and `embed_sum` are computed.

## Why
The in-place update can trip autograd version checks when the codebook path is used under `torch.compile`, especially with the VQ bridge / learnable codebook path where the one-hot tensor can still be needed for backward.

## Tests
- Checked tensor equivalence against the previous in-place operation for shape `[1, 26624, 8192]`.
- A real training with VQ Bridge enabled + torch.compile was tested.
