### PR TITLE
Fix SyntaxError (missing comma) in examples/autoencoder_fvq.py

### DIFF
--- a/examples/autoencoder_fvq.py
+++ b/examples/autoencoder_fvq.py
@@ -141,7 +141,7 @@ def train(
     model = SimpleVQAutoEncoder(
         dim = dim,
         vq_bridge = vq_bridge,
-        rotation_trick = rotation_trick
+        rotation_trick = rotation_trick,
         codebook_size = num_codes,
         learnable_codebook = True,
         in_place_codebook_optimizer = lambda *args, **kwargs: SGD(*args, **kwargs, lr = 1e-3),


### PR DESCRIPTION
`examples/autoencoder_fvq.py` doesn't parse — there's a missing comma after `rotation_trick = rotation_trick` in the `SimpleVQAutoEncoder(...)` call:

```
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

This adds the missing comma so the example imports/runs.
