### PR TITLE
Add Finite Scalar Perturbation (FSP) from VP-VAE

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,30 @@ quantized_out = residual_fsq.get_output_from_indices(indices)
 assert torch.all(quantized == quantized_out)
 ```
 
+### Finite Scalar Perturbation
+
+[VP-VAE](https://arxiv.org/abs/2602.17133) introduces a new quantization paradigm that decouples representation learning from discretization: instead of performing a hard codebook lookup, discretization is treated as structured noise injected into continuous representations. This avoids codebook collapse and leads to more stable training with uniform token utilization.
+
+FSP (Finite Scalar Perturbation) is a practical algorithm derived from this framework by assuming a uniform prior over the activated latents. The resulting method is structurally similar to FSQ — both discretize each scalar independently into fixed levels — but differs in two key aspects. First, during training FSP perturbs the continuous variable itself rather than the quantized output, which provides smoother gradient signals. Second, quantization targets are bin centers derived from the uniform prior, rather than bin boundaries determined by rounding, which leads to better reconstruction quality. These advantages are validated across both visual and auditory tasks.
+
+```python
+import torch
+from vector_quantize_pytorch import FSP
+
+quantizer = FSP(
+    levels = [8, 5, 5, 5],     # number of bins per scalar dimension
+    act_name = 'normal',       # CDF activation: tanh | sigmoid | normal | laplace | cauchy
+    quantize_rate = 0.5,       # 0. = full stochastic perturbation, 1. = no perturbation
+    vector_norm = 'var',       # statistical regularization: none | var | kurt | var_tanh | var_sigmoid | etc.
+)
+
+x = torch.randn(1, 1024, 4)
+quantized, indices, norm_loss, other_info = quantizer(x)
+
+# quantized.shape    (1, 1024, 4)
+# indices.shape      (1, 1024)
+```
+
 ### Lookup Free Quantization
 
 <img src="./images/lfq.png" width="450px"></img>
@@ -864,5 +888,17 @@ assert loss.item() >= 0
     archivePrefix = {arXiv},
     primaryClass = {cs.CV},
     url     = {https://arxiv.org/abs/2404.02905},
+}
+```
+
+```bibtex
+@misc{zhai2026vpvaerethinkingvectorquantization,
+    title   = {VP-VAE: Rethinking Vector Quantization via Adaptive Vector Perturbation},
+    author  = {Linwei Zhai and Han Ding and Mingzhi Lin and Cui Zhao and Fei Wang and Ge Wang and Wang Zhi and Wei Xi},
+    year    = {2026},
+    eprint  = {2602.17133},
+    archivePrefix = {arXiv},
+    primaryClass = {cs.LG},
+    url     = {https://arxiv.org/abs/2602.17133},
 }
 ```

--- a/examples/autoencoder_fsp.py
+++ b/examples/autoencoder_fsp.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env uv run
+# /// script
+# dependencies = [
+#   "torch",
+#   "torchvision",
+#   "tqdm",
+#   "fire",
+# ]
+# ///
+
+from tqdm.auto import trange
+
+import math
+import fire
+import torch
+import torch.nn as nn
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+from torch.optim import AdamW
+
+from vector_quantize_pytorch import FSP, Sequential
+
+# classes
+
+def SimpleFSPAutoEncoder(
+    levels: list[int],
+    act_name: str = 'tanh',
+    quantize_rate: float = 0.5,
+    need_inv_act: bool = False,
+    vector_norm: str = 'var_tanh',
+):
+    return Sequential(
+        nn.Conv2d(1, 16, kernel_size = 3, stride = 1, padding = 1),
+        nn.MaxPool2d(kernel_size = 2, stride = 2),
+        nn.GELU(),
+        nn.Conv2d(16, 32, kernel_size = 3, stride = 1, padding = 1),
+        nn.MaxPool2d(kernel_size = 2, stride = 2),
+        nn.Conv2d(32, len(levels), kernel_size = 1),
+        FSP(
+            levels,
+            channel_first=True,
+            act_name = act_name,
+            quantize_rate = quantize_rate,
+            need_inv_act = need_inv_act,
+            vector_norm = vector_norm,
+        ),
+        nn.Conv2d(len(levels), 32, kernel_size = 3, stride = 1, padding = 1),
+        nn.Upsample(scale_factor = 2, mode = "nearest"),
+        nn.Conv2d(32, 16, kernel_size = 3, stride = 1, padding = 1),
+        nn.GELU(),
+        nn.Upsample(scale_factor = 2, mode = "nearest"),
+        nn.Conv2d(16, 1, kernel_size = 3, stride = 1, padding = 1),
+    )
+
+def train(
+    train_iter = 1000,
+    lr = 3e-4,
+    levels = [8, 6, 5],
+    seed = 1234,
+    batch_size = 256,
+    act_name = 'tanh',
+    quantize_rate = 0.5,
+    need_inv_act = False,
+    vector_norm = 'var_tanh',
+    norm_loss_weight = 1.0,
+):
+    torch.random.manual_seed(seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    num_codes = math.prod(levels)
+
+    model = SimpleFSPAutoEncoder(
+        levels,
+        act_name = act_name,
+        quantize_rate = quantize_rate,
+        need_inv_act = need_inv_act,
+        vector_norm = vector_norm,
+    ).to(device)
+
+    opt = AdamW(model.parameters(), lr = lr)
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.5,), (0.5,))
+    ])
+
+    train_dataset = DataLoader(
+        datasets.FashionMNIST(root = "~/data/fashion_mnist", train = True, download = True, transform = transform),
+        batch_size = batch_size,
+        shuffle = True,
+    )
+
+    def iterate_dataset(data_loader):
+        data_iter = iter(data_loader)
+        while True:
+            try:
+                x, y = next(data_iter)
+            except StopIteration:
+                data_iter = iter(data_loader)
+                x, y = next(data_iter)
+            yield x.to(device), y.to(device)
+
+    dl_iter = iterate_dataset(train_dataset)
+
+    pbar = trange(train_iter)
+
+    for _ in pbar:
+        opt.zero_grad()
+        x, _ = next(dl_iter)
+
+        out, indices, norm_loss, other_info = model(x)
+        out = out.clamp(-1., 1.)
+
+        rec_loss = (out - x).abs().mean()
+        total_loss = rec_loss + norm_loss_weight * norm_loss
+        total_loss.backward()
+
+        opt.step()
+
+        pbar.set_description(
+            f"rec loss: {rec_loss.item():.3f} | "
+            f"norm loss: {norm_loss.item():.4f} | "
+            f"active %: {indices.unique().numel() / num_codes * 100:.3f}"
+        )
+
+if __name__ == "__main__":
+    fire.Fire(train)

--- a/tests/test_fsp.py
+++ b/tests/test_fsp.py
@@ -1,0 +1,162 @@
+import pytest
+import torch
+
+from vector_quantize_pytorch import FSP
+from vector_quantize_pytorch.finite_scalar_perturbation import build_cdf_act
+
+# CDF activation roundtrip
+
+
+@pytest.mark.parametrize("act_name", ("tanh", "sigmoid", "normal", "laplace", "cauchy"))
+def test_cdf_act_roundtrip(act_name):
+    act_func, inv_act_func = build_cdf_act(act_name)
+
+    x = torch.randn(64, 10)
+    y = act_func(x)
+    x_hat = inv_act_func(y)
+    assert (y > 0.0).all() and (y < 1.0).all()
+    assert torch.allclose(x, x_hat, atol=1e-4), (
+        f"{act_name} roundtrip error: {(x_hat - x).abs().max()}"
+    )
+
+
+# FSP
+
+
+def test_fsp_basic():
+    fsp = FSP(levels=[8, 5, 5, 5], act_name="normal", vector_norm="none")
+
+    x = torch.randn(1, 1024, 4)
+    quantized, indices, norm_loss, other_info = fsp(x)
+    assert quantized.shape == x.shape
+    assert indices.shape == (1, 1024)
+    assert norm_loss.item() == 0.0
+    assert isinstance(other_info, dict)
+
+
+def test_fsp_eval_roundtrip():
+    fsp = FSP(levels=[8, 5, 5, 5])
+    fsp.eval()
+
+    x = torch.randn(1, 1024, 4)
+    quantized, indices, *_ = fsp(x)
+    recovered = fsp.indices_to_codes(indices)
+    assert torch.allclose(quantized, recovered, atol=1e-5), (
+        f"max diff: {(quantized - recovered).abs().max()}"
+    )
+
+
+def test_fsp_index_encoding():
+    fsp = FSP(levels=[8, 5, 5, 5])
+
+    # Test known level_indices (max values for each dimension)
+    level_indices = torch.tensor([[[7, 4, 4, 4]]])  # shape: (1, 1, 4)
+    flat_index = fsp.level_indices_to_indices(level_indices)
+    # Expected: 7*(5*5*5) + 4*(5*5) + 4*5 + 4 = 875 + 100 + 20 + 4 = 999
+    assert flat_index.item() == 999
+
+    # Verify decoding recovers original level_indices
+    recovered = fsp.indices_to_level_indices(flat_index)
+    assert torch.equal(level_indices, recovered)
+
+    # Test zero indices (boundary case)
+    level_indices_zero = torch.tensor([[[0, 0, 0, 0]]])
+    flat_index_zero = fsp.level_indices_to_indices(level_indices_zero)
+    assert flat_index_zero.item() == 0
+    recovered_zero = fsp.indices_to_level_indices(flat_index_zero)
+    assert torch.equal(level_indices_zero, recovered_zero)
+
+
+def test_fsp_quantize_rate_one():
+    fsp = FSP(levels=[8, 5, 5, 5], quantize_rate=1.0)
+    fsp.train()
+
+    x = torch.randn(1, 64, 4)
+    out1, *_ = fsp(x)
+    out2, *_ = fsp(x)
+    assert torch.allclose(out1, out2)
+
+
+def test_fsp_image_input():
+    fsp = FSP(levels=[8, 5, 5, 5], dim=4, channel_first=True)
+    fsp.eval()
+
+    x = torch.randn(2, 4, 8, 8)
+    quantized, indices, *_ = fsp(x)
+    assert quantized.shape == x.shape
+    assert indices.shape == (2, 8, 8)
+
+    recovered = fsp.indices_to_codes(indices)
+    assert recovered.shape == x.shape
+    assert torch.allclose(quantized, recovered, atol=1e-5)
+
+
+def test_fsp_with_dim_projection():
+    """dim != codebook_dim requires projection layers."""
+    fsp = FSP(levels=[8, 5, 5, 5], dim=256)
+    fsp.eval()
+
+    assert fsp.has_projections
+
+    x = torch.randn(1, 64, 256)
+    quantized, indices, _, _ = fsp(x)
+    assert quantized.shape == x.shape
+    assert indices.shape == (1, 64)
+
+    recovered = fsp.indices_to_codes(indices)
+    assert recovered.shape == x.shape
+    assert torch.allclose(quantized, recovered, atol=1e-4)
+
+
+@pytest.mark.parametrize("dtype,use_autocast", [
+    (torch.float32, False),
+    (torch.float64, False),
+    (torch.float16, True),
+    (torch.bfloat16, True),
+])
+def test_fsp_training(dtype, use_autocast):
+    """Test FSP with different precisions, autocast, and gradient flow."""
+    if torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    model = torch.nn.Sequential(
+        torch.nn.Linear(256, 256),
+        FSP(levels=[8, 5, 5, 5], dim=256),
+        torch.nn.Linear(256, 256),
+    ).to(device).to(dtype)
+    model.train()
+
+    x = torch.randn(2, 64, 256, dtype=dtype, device=device, requires_grad=True)
+    # Forward pass with or without autocast
+    if use_autocast:
+        with torch.amp.autocast(device, dtype=dtype):
+            h1 = model[0](x)
+            quantized, indices, norm_loss, other_info = model[1](h1)
+            out = model[2](quantized)
+    else:
+        h1 = model[0](x)
+        quantized, indices, norm_loss, other_info = model[1](h1)
+        out = model[2](quantized)
+
+    # Verify output dtype matches input
+    assert quantized.dtype == dtype
+    assert indices.dtype == torch.int32
+
+    # Verify indices are valid (no NaN/Inf from precision issues)
+    assert not indices.isnan().any()
+    assert (indices >= 0).all() and (indices < model[1].codebook_size).all()
+
+    # Backward pass - verify gradient flow
+    loss = out.sum() + norm_loss
+    loss.backward()
+
+    assert x.grad is not None, "Input gradient should exist"
+    assert not x.grad.isnan().any()
+    assert not x.grad.isinf().any()
+
+    for parameter in model.parameters():
+        assert parameter.grad is not None
+        assert not parameter.grad.isnan().any()
+        assert not parameter.grad.isinf().any()

--- a/vector_quantize_pytorch/__init__.py
+++ b/vector_quantize_pytorch/__init__.py
@@ -2,6 +2,7 @@ from vector_quantize_pytorch.vector_quantize_pytorch import VectorQuantize
 from vector_quantize_pytorch.residual_vq import ResidualVQ, GroupedResidualVQ
 from vector_quantize_pytorch.random_projection_quantizer import RandomProjectionQuantizer
 from vector_quantize_pytorch.finite_scalar_quantization import FSQ
+from vector_quantize_pytorch.finite_scalar_perturbation import FSP
 from vector_quantize_pytorch.lookup_free_quantization import LFQ
 from vector_quantize_pytorch.residual_lfq import ResidualLFQ, GroupedResidualLFQ
 from vector_quantize_pytorch.residual_fsq import ResidualFSQ, GroupedResidualFSQ

--- a/vector_quantize_pytorch/finite_scalar_perturbation.py
+++ b/vector_quantize_pytorch/finite_scalar_perturbation.py
@@ -1,0 +1,363 @@
+"""
+Finite Scalar Perturbation (FSP)
+https://arxiv.org/abs/2602.17133
+
+Each scalar is mapped to [0, 1] via a CDF activation, then quantized into
+discrete bins. During training, stochastic perturbation within bins provides
+smoother gradient signals and regularization.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+import torch
+from einops import rearrange
+from torch import int32, nn
+from torch.nn import Module
+
+
+def default(*args):
+    for arg in args:
+        if arg is not None:
+            return arg
+    return None
+
+
+# CDF activation functions: (-inf, +inf) -> [0, 1]
+# inv activation functions: (0, 1) -> (-∞, +∞)
+
+def tanh_act(z: torch.Tensor) -> torch.Tensor:
+    return (torch.tanh(z) + 1.0) / 2.0
+
+
+def tanh_inv_act(p: torch.Tensor) -> torch.Tensor:
+    return torch.arctanh(p * 2.0 - 1.0)
+
+
+def sigmoid_act(z: torch.Tensor) -> torch.Tensor:
+    return torch.sigmoid(z)
+
+
+def sigmoid_inv_act(p: torch.Tensor) -> torch.Tensor:
+    return torch.logit(p)
+
+
+_SQRT2 = math.sqrt(2.0)
+
+
+def normal_act(z: torch.Tensor) -> torch.Tensor:
+    return (1.0 + torch.erf(z / _SQRT2)) / 2.0
+
+
+def normal_inv_act(p: torch.Tensor) -> torch.Tensor:
+    return torch.erfinv(2.0 * p - 1.0) * _SQRT2
+
+
+def laplace_act(z: torch.Tensor) -> torch.Tensor:
+    return 0.5 * (1.0 + torch.sign(z) * (1.0 - torch.exp(-torch.abs(z))))
+
+
+def laplace_inv_act(p: torch.Tensor) -> torch.Tensor:
+    return -torch.sign(p - 0.5) * torch.log(1.0 - 2.0 * torch.abs(p - 0.5))
+
+
+def cauchy_act(z: torch.Tensor) -> torch.Tensor:
+    return torch.arctan(z) / torch.pi + 0.5
+
+
+def cauchy_inv_act(p: torch.Tensor) -> torch.Tensor:
+    return torch.tan((p - 0.5) * torch.pi)
+
+
+_CDF_REGISTRY = {
+    "tanh": (tanh_act, tanh_inv_act),
+    "sigmoid": (sigmoid_act, sigmoid_inv_act),
+    "normal": (normal_act, normal_inv_act),
+    "laplace": (laplace_act, laplace_inv_act),
+    "cauchy": (cauchy_act, cauchy_inv_act),
+}
+
+
+def build_cdf_act(act_name: str) -> tuple[Callable, Callable]:
+    assert act_name in _CDF_REGISTRY, (
+        f"CDF activation {act_name} not available: {list(_CDF_REGISTRY.keys())}"
+    )
+    return _CDF_REGISTRY[act_name]
+
+
+# batch statistics
+
+
+def batch_stats(batch: torch.Tensor, eps: float = 1e-8):
+    variance, mean = torch.var_mean(batch, dim=0, unbiased=True)
+    std = variance.sqrt().clamp_min(eps)
+    z_scores = (batch - mean) / std
+    skewness = torch.mean(z_scores.pow(3), dim=0)
+    kurtosis = torch.mean(z_scores.pow(4), dim=0) - 3.0
+    return mean, variance, skewness, kurtosis
+
+
+# VectorNorm — statistical regularization
+
+
+class VectorNorm(nn.Module):
+    def __init__(
+        self,
+        l1_target: float = 0.0,
+        l1_weight: float = 0.1,
+        l2_target: float = 1.0,
+        l2_weight: float = 0.07,
+        l3_target: float = 0.0,
+        l3_weight: float = 0.06,
+        l4_target: float = 0.0,
+        l4_weight: float = 0.05,
+        eps: float = 1e-8,
+    ):
+        super().__init__()
+
+        self.l1_target, self.l1_weight = l1_target, l1_weight
+        self.l2_target, self.l2_weight = l2_target, l2_weight
+        self.l3_target, self.l3_weight = l3_target, l3_weight
+        self.l4_target, self.l4_weight = l4_target, l4_weight
+        self.eps = eps
+
+    def forward(self, z: torch.Tensor) -> tuple[torch.Tensor, dict]:
+        mean, variance, skewness, kurtosis = batch_stats(z, self.eps)
+        norm_loss = (
+            ((mean - self.l1_target) ** 2).mean() * self.l1_weight
+            + ((variance - self.l2_target) ** 2).mean() * self.l2_weight
+            + ((skewness - self.l3_target) ** 2).mean() * self.l3_weight
+            + ((kurtosis - self.l4_target) ** 2).mean() * self.l4_weight
+        )
+
+        return norm_loss, {
+            "mean": mean,
+            "variance": variance,
+            "skewness": skewness,
+            "kurtosis": kurtosis,
+        }
+
+    @classmethod
+    def build(cls, name):
+        presets = {
+            "none": dict(
+                l1_weight=0.0,
+                l2_weight=0.0,
+                l3_weight=0.0,
+                l4_weight=0.0,
+            ),
+            "var": dict(
+                l1_target=0.0,
+                l1_weight=0.1,
+                l2_target=1.0,
+                l2_weight=0.07,
+                l3_weight=0.0,
+                l4_weight=0.0,
+            ),
+            "kurt": dict(
+                l1_target=0.0,
+                l1_weight=0.1,
+                l2_target=1.0,
+                l2_weight=0.07,
+                l3_target=0.0,
+                l3_weight=0.06,
+                l4_target=0.0,
+                l4_weight=0.05,
+            ),
+            "var_tanh": dict(
+                l1_target=0.0,
+                l1_weight=0.1,
+                l2_target=0.8225,
+                l2_weight=0.07,
+                l3_weight=0.0,
+                l4_weight=0.0,
+            ),
+            "var_sigmoid": dict(
+                l1_target=0.0,
+                l1_weight=0.1,
+                l2_target=3.29,
+                l2_weight=0.07,
+                l3_weight=0.0,
+                l4_weight=0.0,
+            ),
+            "var_laplace": dict(
+                l1_target=0.0,
+                l1_weight=0.1,
+                l2_target=2.0,
+                l2_weight=0.07,
+                l3_weight=0.0,
+                l4_weight=0.0,
+            ),
+        }
+
+        assert name in presets, (
+            f"unknown vector_norm preset: {name}, available: {list(presets.keys())}"
+        )
+        return cls(**presets[name])
+
+
+# FSP
+
+
+class FSP(Module):
+    def __init__(
+        self,
+        levels: list[int] | tuple[int, ...],
+        dim: int | None = None,
+        channel_first=False,
+        projection_has_bias=True,
+        act_name="tanh",
+        quantize_rate=0.0,
+        need_inv_act=False,
+        vector_norm="var_tanh",
+    ):
+        super().__init__()
+
+        # Input validation
+        assert 0.0 <= quantize_rate <= 1.0, (
+            f"quantize_rate must be in [0.0, 1.0], got {quantize_rate}"
+        )
+
+        codebook_dim = len(levels)
+        self.codebook_dim = codebook_dim
+
+        self.dim = default(dim, self.codebook_dim)
+        self.channel_first = channel_first
+
+        # levels and mixed-radix basis
+
+        _levels = torch.tensor(levels, dtype=int32)
+        self.register_buffer("_levels", _levels, persistent=False)
+
+        _basis = torch.cumprod(
+            torch.tensor([1] + list(levels[:-1])), dim=0, dtype=int32
+        )
+        self.register_buffer("_basis", _basis, persistent=False)
+
+        self.codebook_size = _levels.prod().item()
+
+        # projections
+        self.has_projections = self.dim != self.codebook_dim
+        if self.has_projections:
+            self.project_in = nn.Linear(
+                self.dim, self.codebook_dim, bias=projection_has_bias
+            )
+            self.project_out = nn.Linear(
+                self.codebook_dim, self.dim, bias=projection_has_bias
+            )
+        else:
+            self.project_in = nn.Identity()
+            self.project_out = nn.Identity()
+
+        # CDF activation
+        self.act_name = act_name
+        self.act_func, self.inv_act_func = build_cdf_act(act_name)
+        self.need_inv_act = need_inv_act
+
+        self.quantize_rate = quantize_rate
+
+        self.vector_norm = VectorNorm.build(vector_norm)
+
+    def __repr__(self):
+        return (
+            f"FSP(\n"
+            f"  levels={self._levels.tolist()},\n"
+            f"  codebook_size={self.codebook_size},\n"
+            f"  codebook_dim={self.codebook_dim},\n"
+            f"  dim={self.dim},\n"
+            f"  act_name='{self.act_name}',\n"
+            f"  need_inv_act={self.need_inv_act},\n"
+            f"  quantize_rate={self.quantize_rate}\n"
+            f")"
+        )
+
+    def quantize_act_value(self, act_z, eps):
+        # quantize [0,1] values to bin midpoints with straight-through gradients
+        level_indices = (act_z.clamp_max(1.0 - eps) * self._levels).floor()
+        q_act_z = (level_indices + 0.5) / self._levels
+        q_act_z = act_z + (q_act_z - act_z).detach()
+        return q_act_z, level_indices.detach()
+
+    def level_indices_to_indices(self, level_indices):
+        return (level_indices * self._basis).sum(dim=-1).to(int32)
+
+    def indices_to_level_indices(self, indices):
+        indices = rearrange(indices, "... -> ... 1")
+        return (indices // self._basis) % self._levels
+
+    def indices_to_act_value(self, indices: torch.Tensor):
+        level_indices = self.indices_to_level_indices(indices).float()
+        return (level_indices + 0.5) / self._levels
+
+    def indices_to_codes(self, indices: torch.Tensor, eps: float = 1e-6):
+        q_act_z = self.indices_to_act_value(indices)
+        if self.need_inv_act:
+            q_z = self.inv_act_func(q_act_z.clamp(eps, 1.0 - eps))
+        else:
+            # q_z = q_act_z * 2 - 1
+            q_z = (q_act_z - 0.5) / 0.28867513459481287
+
+        codes = self.project_out(q_z)
+
+        if self.channel_first:
+            codes = rearrange(codes, "b ... d -> b d ...")
+
+        return codes
+
+    def forward(
+        self, z, eps: float | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict]:
+        eps = eps or torch.finfo(z.dtype).eps
+
+        if self.channel_first:
+            z = rearrange(z, "b d ... -> b ... d")
+        z_shape = z.shape
+        assert z_shape[-1] == self.dim, (
+            f"expected dimension of {self.dim} but found dimension of {z_shape[-1]}"
+        )
+        z = z.reshape(-1, self.dim)
+        z = self.project_in(z)
+
+        norm_loss, norm_info = self.vector_norm(z)
+
+        # CDF activation: map to [0, 1]
+        act_z = self.act_func(z)
+        q_act_z, level_indices = self.quantize_act_value(act_z, eps=eps)
+        other_info = {}
+
+        quantize_rate = self.quantize_rate if self.training else 1.0
+
+        if quantize_rate < 1.0:
+            p_max_norm = 1.0 / (self._levels * 2)
+            perturbations = p_max_norm * (torch.rand_like(act_z) * 2.0 - 1.0)
+            proposal = act_z + perturbations
+            accept_mask = (proposal > 0.0) & (proposal < 1.0)
+            other_info["p_accept_prob"] = accept_mask.float().mean()
+            p_act_z = torch.where(accept_mask, proposal, act_z)
+
+            p_mask = torch.rand_like(q_act_z) > quantize_rate
+            q_act_z = torch.where(p_mask, p_act_z, q_act_z)
+
+        if self.need_inv_act:
+            q_z = self.inv_act_func(q_act_z.clamp(eps, 1.0 - eps))
+            q_z = z + (q_z - z).detach()
+        else:
+            # q_z = q_act_z * 2 - 1
+            q_z = (q_act_z - 0.5) / 0.28867513459481287  # to make q_z.var() -> 1.0
+
+        indices = self.level_indices_to_indices(level_indices)
+        q_z = self.project_out(q_z)
+
+        level_indices = level_indices.reshape(z_shape[:-1] + (-1,))
+        indices = indices.reshape(z_shape[:-1])
+        q_z = q_z.reshape(z_shape)
+        if self.channel_first:
+            q_z = rearrange(q_z, "b ... d -> b d ...")
+
+        return q_z, indices, norm_loss, {
+            "level_indices": level_indices,
+            'norm_info': norm_info,
+            **other_info
+        }

--- a/vector_quantize_pytorch/utils.py
+++ b/vector_quantize_pytorch/utils.py
@@ -8,6 +8,7 @@ from vector_quantize_pytorch.vector_quantize_pytorch import VectorQuantize
 from vector_quantize_pytorch.residual_vq import ResidualVQ, GroupedResidualVQ
 from vector_quantize_pytorch.random_projection_quantizer import RandomProjectionQuantizer
 from vector_quantize_pytorch.finite_scalar_quantization import FSQ
+from vector_quantize_pytorch.finite_scalar_perturbation import FSP
 from vector_quantize_pytorch.lookup_free_quantization import LFQ
 from vector_quantize_pytorch.residual_lfq import ResidualLFQ, GroupedResidualLFQ
 from vector_quantize_pytorch.residual_fsq import ResidualFSQ, GroupedResidualFSQ
@@ -29,6 +30,7 @@ QUANTIZE_KLASSES = (
     GroupedResidualLFQ,
     ResidualFSQ,
     GroupedResidualFSQ,
+    FSP,
     LatentQuantize,
     HierarchicalVQ
 )


### PR DESCRIPTION
## Summary

This PR adds FSP (Finite Scalar Perturbation), a lightweight quantization module from our paper VP-VAE: Rethinking Vector Quantization via Adaptive Vector Perturbation (https://arxiv.org/abs/2602.17133).

## Why FSP?

VQ-VAEs suffer from codebook collapse because representation learning and codebook optimization are tightly coupled during training. Our paper proposes a perturbation-first paradigm: instead of performing a hard codebook lookup during training, we inject structured perturbations that emulate the effect of future quantization — so the decoder learns to be robust to quantization error without ever seeing an explicit codebook.

FSP is the practical, lightweight instantiation of this idea. It assumes an approximately uniform prior over bounded latents (enforced via CDF-like activations) and replaces training-time quantization with bounded centered perturbations + centroid-based decoding. Structurally it is very close to FSQ — both discretize each scalar dimension into fixed levels — but differs in two key ways:

1. Training: FSP perturbs the continuous latent (not the quantized output), providing smoother gradient signals.
2. Decoding: Quantization targets are bin centroids (Lloyd–Max optimal for a uniform source) rather than bin boundaries from rounding.

## Results vs. FSQ

In our experiments, across both modalities (image & audio), all codebook sizes (256–16384), and both in-domain and OOD benchmarks, FSP consistently outperforms FSQ on every reconstruction metric — while maintaining comparable codebook utilization and computational cost.